### PR TITLE
Implement basic live score backend and UI

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "test": "react-scripts test",
     "eject": "react-scripts eject",
     "predeploy": "npm run build",
-    "deploy": "gh-pages -d build"
+    "deploy": "gh-pages -d build",
+    "start-server": "node server.js"
   },
   "eslintConfig": {
     "extends": [

--- a/public/teams.json
+++ b/public/teams.json
@@ -1,0 +1,4 @@
+[
+  { "id": 1, "name": "Team 1", "scores": [] },
+  { "id": 2, "name": "Team 2", "scores": [] }
+]

--- a/server.js
+++ b/server.js
@@ -1,0 +1,60 @@
+const express = require('express');
+const app = express();
+app.use(express.json());
+
+// In-memory data structures
+let teams = [
+  { id: 1, name: 'Team 1', scores: [] },
+  { id: 2, name: 'Team 2', scores: [] }
+];
+let closestToPinHole = null;
+let closestToPinDistance = null;
+
+function getLowestScores() {
+  const holeCount = Math.max(...teams.map(t => t.scores.length));
+  const lowest = [];
+  for (let i = 0; i < holeCount; i++) {
+    let min = Infinity;
+    teams.forEach(t => {
+      if (typeof t.scores[i] === 'number' && t.scores[i] < min) {
+        min = t.scores[i];
+      }
+    });
+    if (min !== Infinity) {
+      lowest.push({ hole: i + 1, score: min });
+    }
+  }
+  return lowest;
+}
+
+app.post('/team/:id/score', (req, res) => {
+  const team = teams.find(t => t.id === parseInt(req.params.id));
+  if (!team) return res.status(404).send('Team not found');
+  const { hole, strokes } = req.body;
+  if (typeof hole !== 'number' || typeof strokes !== 'number') {
+    return res.status(400).send('Invalid payload');
+  }
+  team.scores[hole - 1] = strokes;
+  res.json(team);
+});
+
+app.get('/skins', (req, res) => {
+  const lowest = getLowestScores();
+  res.json({ lowest });
+});
+
+app.post('/closest-to-pin', (req, res) => {
+  const { hole, distance } = req.body;
+  if (typeof hole !== 'number' || typeof distance !== 'number') {
+    return res.status(400).send('Invalid payload');
+  }
+  closestToPinHole = hole;
+  closestToPinDistance = distance;
+  res.json({ hole: closestToPinHole, distance: closestToPinDistance });
+});
+
+app.get('/closest-to-pin', (req, res) => {
+  res.json({ hole: closestToPinHole, distance: closestToPinDistance });
+});
+
+app.listen(4000, () => console.log('Server running on port 4000'));

--- a/src/GolfScrambleApp.tsx
+++ b/src/GolfScrambleApp.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { Calendar, Users, Trophy, UserPlus, Settings, TrendingUp, Clock, MapPin } from 'lucide-react';
+import LiveScore from './LiveScore';
 
 interface Player {
   id: number;
@@ -125,6 +126,7 @@ const GolfScrambleApp = () => {
               { id: 'signup', label: 'Sign Up', icon: UserPlus },
               { id: 'teams', label: 'Teams', icon: Users },
               { id: 'players', label: 'Player Stats', icon: TrendingUp },
+              { id: 'live', label: 'Live Scores', icon: Trophy },
               { id: 'manage', label: 'Manage', icon: Settings }
             ].map(({ id, label, icon: Icon }) => (
               <button
@@ -278,6 +280,15 @@ const GolfScrambleApp = () => {
                   )}
                 </div>
               )}
+            </div>
+          </div>
+        )}
+
+        {/* Live Scores Tab */}
+        {activeTab === 'live' && (
+          <div className="space-y-6">
+            <div className="bg-white rounded-lg shadow-sm p-6">
+              <LiveScore />
             </div>
           </div>
         )}

--- a/src/LiveScore.tsx
+++ b/src/LiveScore.tsx
@@ -1,0 +1,79 @@
+import React, { useEffect, useState } from 'react';
+
+interface Team {
+  id: number;
+  name: string;
+  scores: number[];
+}
+
+interface LowestScore {
+  hole: number;
+  score: number;
+}
+
+const LiveScore: React.FC = () => {
+  const [teams, setTeams] = useState<Team[]>([]);
+  const [skins, setSkins] = useState<LowestScore[]>([]);
+  const [closest, setClosest] = useState<{hole: number|null, distance: number|null}>({hole: null, distance: null});
+
+  const fetchData = async () => {
+    try {
+      const teamRes = await fetch('/teams.json'); // placeholder for team listing
+      if (teamRes.ok) {
+        setTeams(await teamRes.json());
+      }
+    } catch (e) {
+      // ignore
+    }
+    try {
+      const res = await fetch('http://localhost:4000/skins');
+      if (res.ok) {
+        const data = await res.json();
+        setSkins(data.lowest);
+      }
+    } catch (e) {
+      // ignore
+    }
+    try {
+      const res = await fetch('http://localhost:4000/closest-to-pin');
+      if (res.ok) {
+        setClosest(await res.json());
+      }
+    } catch (e) {
+      // ignore
+    }
+  };
+
+  useEffect(() => {
+    fetchData();
+    const id = setInterval(fetchData, 5000);
+    return () => clearInterval(id);
+  }, []);
+
+  return (
+    <div className="space-y-4">
+      <h2 className="text-xl font-semibold">Live Scores</h2>
+      <div className="bg-white rounded-lg shadow p-4">
+        {teams.map(team => (
+          <div key={team.id} className="mb-2">
+            <div className="font-medium">{team.name}</div>
+            <div className="text-sm text-gray-700">Scores: {team.scores.join(', ')}</div>
+          </div>
+        ))}
+      </div>
+      <h3 className="text-lg font-semibold">Skins</h3>
+      <ul className="list-disc pl-5">
+        {skins.map(s => (
+          <li key={s.hole}>Hole {s.hole}: {s.score}</li>
+        ))}
+      </ul>
+      {closest.hole && (
+        <div className="mt-4 p-4 bg-green-50 rounded">
+          Closest to the Pin - Hole {closest.hole}: {closest.distance} ft
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default LiveScore;


### PR DESCRIPTION
## Summary
- add simple Express server for score updates, skins and closest-to-pin
- expose script `start-server`
- create `LiveScore` React component and integrate new tab
- include placeholder teams JSON data

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850786f0ccc8326b2d21bf9d3190e62