### PR TITLE
Add player profile route

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "react-scripts": "5.0.1",
     "typescript": "^4.9.5",
     "lucide-react": "^0.294.0",
+    "react-router-dom": "^6.14.1",
     "tailwindcss": "^3.3.0",
     "postcss": "^8.4.31",
     "autoprefixer": "^10.4.16"

--- a/src/GolfScrambleApp.tsx
+++ b/src/GolfScrambleApp.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { Calendar, Users, Trophy, UserPlus, Settings, TrendingUp, Clock, MapPin } from 'lucide-react';
+import { Link } from 'react-router-dom';
 
 interface Player {
   id: number;
@@ -187,7 +188,11 @@ const GolfScrambleApp = () => {
                           {player.name.charAt(0)}
                         </div>
                         <div>
-                          <div className="font-medium">{player.name}</div>
+                          <div className="font-medium">
+                            <Link to={`/player/${player.id}`} className="hover:underline">
+                              {player.name}
+                            </Link>
+                          </div>
                           <div className="text-sm text-gray-600">Handicap: {player.handicap}</div>
                         </div>
                       </div>
@@ -213,7 +218,11 @@ const GolfScrambleApp = () => {
                           {player.name.charAt(0)}
                         </div>
                         <div>
-                          <div className="font-medium">{player.name}</div>
+                          <div className="font-medium">
+                            <Link to={`/player/${player.id}`} className="hover:underline">
+                              {player.name}
+                            </Link>
+                          </div>
                           <div className="text-sm text-gray-600">Handicap: {player.handicap}</div>
                         </div>
                       </div>
@@ -257,7 +266,12 @@ const GolfScrambleApp = () => {
                             <div className="w-6 h-6 bg-green-600 rounded-full flex items-center justify-center text-white text-xs font-medium">
                               {player.name.charAt(0)}
                             </div>
-                            <span className="text-sm">{player.name} (HC: {player.handicap})</span>
+                            <span className="text-sm">
+                              <Link to={`/player/${player.id}`} className="hover:underline">
+                                {player.name}
+                              </Link>{' '}
+                              (HC: {player.handicap})
+                            </span>
                           </div>
                         ))}
                       </div>

--- a/src/PlayerProfile.tsx
+++ b/src/PlayerProfile.tsx
@@ -1,0 +1,73 @@
+import React, { useEffect, useState } from 'react';
+import { useParams, Link } from 'react-router-dom';
+
+interface PlayerProfileData {
+  id: number;
+  name: string;
+  ranking: 'A' | 'B' | 'C' | 'D';
+  avgTeamScore: number;
+  skinsWon: number;
+  ctpAwards: number;
+}
+
+const PlayerProfile = () => {
+  const { id } = useParams<{ id: string }>();
+  const [profile, setProfile] = useState<PlayerProfileData | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    async function fetchProfile() {
+      try {
+        const res = await fetch(`/api/players/${id}`);
+        if (!res.ok) {
+          throw new Error('Failed to fetch');
+        }
+        const data: PlayerProfileData = await res.json();
+        setProfile(data);
+      } catch (err) {
+        console.error(err);
+      } finally {
+        setLoading(false);
+      }
+    }
+
+    fetchProfile();
+  }, [id]);
+
+  if (loading) {
+    return <div className="p-6">Loading...</div>;
+  }
+
+  if (!profile) {
+    return <div className="p-6">Player not found.</div>;
+  }
+
+  return (
+    <div className="min-h-screen bg-green-50">
+      <div className="bg-white shadow-sm p-4 flex items-center justify-between">
+        <h1 className="text-xl font-semibold">{profile.name} Profile</h1>
+        <Link to="/" className="text-green-600 hover:underline">Back</Link>
+      </div>
+      <div className="max-w-xl mx-auto p-6 space-y-4">
+        <div className="bg-white p-4 rounded-lg shadow flex justify-between">
+          <span className="font-medium">Ranking</span>
+          <span className="font-semibold">{profile.ranking}</span>
+        </div>
+        <div className="bg-white p-4 rounded-lg shadow flex justify-between">
+          <span className="font-medium">Average Team Score</span>
+          <span className="font-semibold">{profile.avgTeamScore.toFixed(1)}</span>
+        </div>
+        <div className="bg-white p-4 rounded-lg shadow flex justify-between">
+          <span className="font-medium">Skins Won</span>
+          <span className="font-semibold">{profile.skinsWon}</span>
+        </div>
+        <div className="bg-white p-4 rounded-lg shadow flex justify-between">
+          <span className="font-medium">Closest-to-Pin Awards</span>
+          <span className="font-semibold">{profile.ctpAwards}</span>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default PlayerProfile;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
+import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import GolfScrambleApp from './GolfScrambleApp';
+import PlayerProfile from './PlayerProfile';
 
 const root = ReactDOM.createRoot(
   document.getElementById('root') as HTMLElement
@@ -9,6 +11,11 @@ const root = ReactDOM.createRoot(
 
 root.render(
   <React.StrictMode>
-    <GolfScrambleApp />
+    <BrowserRouter>
+      <Routes>
+        <Route path="/" element={<GolfScrambleApp />} />
+        <Route path="/player/:id" element={<PlayerProfile />} />
+      </Routes>
+    </BrowserRouter>
   </React.StrictMode>
-); 
+);


### PR DESCRIPTION
## Summary
- add `react-router-dom` for routing
- create `PlayerProfile` component to show ranking, avg score, skins, and closest-to-pin awards
- wire up new route in `index.tsx`
- link player names to their profile pages

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850787101888326883f32804958b658