### PR TITLE
Fix webhook handlers: remove updated_at from challenge_payments updates

### DIFF
--- a/server.js
+++ b/server.js
@@ -44,7 +44,7 @@ async function handlePaymentIntentSucceeded(paymentIntent) {
     // Update challenge payments
     await client.query(
       `UPDATE challenge_payments
-       SET payment_status = 'completed', updated_at = CURRENT_TIMESTAMP
+       SET payment_status = 'completed'
        WHERE payment_reference = $1`,
       [paymentIntent.id]
     );
@@ -90,7 +90,7 @@ async function handlePaymentIntentFailed(paymentIntent) {
 
     await client.query(
       `UPDATE challenge_payments
-       SET payment_status = 'failed', updated_at = CURRENT_TIMESTAMP
+       SET payment_status = 'failed'
        WHERE payment_reference = $1`,
       [paymentIntent.id]
     );


### PR DESCRIPTION
- challenge_payments table doesn't have updated_at column
- Fixes PostgreSQL error 42703 (column does not exist)
- Keeps updated_at for signup_payments and signup_registrations tables